### PR TITLE
pub the fields of HistogramCount and SummaryCount

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,7 +152,7 @@ pub struct SummaryCount {
 }
 
 #[derive(Debug, Eq, PartialEq)]
-pub struct Labels(pub HashMap<String, String>);
+pub struct Labels(HashMap<String, String>);
 
 impl Labels {
     fn new() -> Labels {


### PR DESCRIPTION
hello, I've met a case to parse the prometheus metrics text and found prometheus-parse-rs, but unfortunately the fields of HistogramCount and SummaryCount are all private.

this PR public the fields of HistogramCount and SummaryCount so the users could take these values.

regards.