### PR TITLE
Fix histogram parsing in presence of labels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,6 @@ homepage = "https://github.com/ccakes/prometheus-parse-rs"
 
 [dependencies]
 chrono = "^0.4"
+itertools = "^0.10"
 lazy_static = "^1.4"
 regex = "^1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,7 +180,9 @@ impl Labels {
 impl Deref for Labels {
     type Target = HashMap<String, String>;
 
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -532,4 +534,3 @@ rpc_duration_seconds_count 2693
         );
     }
 }
-


### PR DESCRIPTION
Labelled histograms are not recognised by the current parser, they are returned as Untyped. This fixes the label parsing to preserve them (while also extracting the bucket label, to avoid confusion).
 
I also regularised the metric name by removing "_bucket", because the metric name ought to match the prometheus metric name (and this is the only important instance where it doesn't).

I've added a unit test that validates parsing of histograms and summaries. I have not validated the summary code beyond this unit test.