### PR TITLE
Disable unused time feature for chrono dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ccakes/prometheus-parse-rs"
 homepage = "https://github.com/ccakes/prometheus-parse-rs"
 
 [dependencies]
-chrono = "^0.4"
+chrono = { version = "^0.4", default-features = false, features = ["clock", "std"] }
 itertools = "^0.10"
 lazy_static = "^1.4"
 regex = "^1.3"


### PR DESCRIPTION
The chrono "oldtime" feature is enabled by default and shouldn't be used because it pulls in an old version of the "time" crate with known vulnerabilities.