### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,14 @@ keywords = ["prometheus", "parser"]
 repository = "https://github.com/ccakes/prometheus-parse-rs"
 homepage = "https://github.com/ccakes/prometheus-parse-rs"
 
+[features]
+default = ["serde"]
+serde1 = []
+serde = ["dep:serde", "serde1", "chrono/serde"]
+
 [dependencies]
 chrono = "^0.4"
 itertools = "^0.10"
 lazy_static = "^1.4"
 regex = "^1.3"
+serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@ use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
 
+#[cfg(feature = "serde1")]
+use serde::{Serialize, Deserialize};
+
 use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::ops::Deref;
@@ -120,6 +123,7 @@ impl<'a> LineInfo<'a> {
     }
 }
 
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
 pub struct Sample {
     pub metric: String,
@@ -151,18 +155,21 @@ fn parse_bucket(s: &str, label: &str) -> Option<(Labels, f64)> {
     value.map(|v| (Labels(labs), v))
 }
 
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
 pub struct HistogramCount {
     pub less_than: f64,
     pub count: f64,
 }
 
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
 pub struct SummaryCount {
     pub quantile: f64,
     pub count: f64,
 }
 
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq)]
 pub struct Labels(HashMap<String, String>);
 
@@ -214,6 +221,7 @@ impl core::fmt::Display for Labels {
     }
 }
 
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq)]
 pub enum Value {
     Counter(f64),
@@ -236,6 +244,7 @@ impl Value {
     }
 }
 
+#[cfg_attr(feature = "serde1", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Scrape {
     pub docs: HashMap<String, String>,


### PR DESCRIPTION
I needed serde support in a small project, and followed the [api-guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html#data-structures-implement-serdes-serialize-deserialize-c-serde) in doing so. 

Is this desirable in upstream?