### PR TITLE
Fix labels display

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -200,7 +200,7 @@ impl core::fmt::Display for Labels {
                 self.iter()
                     .collect::<BTreeMap<_, _>>()
                     .into_iter()
-                    .map(|(k, v)| format!(r#"{}="{}"#, k, v)),
+                    .map(|(k, v)| format!(r#"{}="{}""#, k, v)),
                 ",".to_string()
             )
             .collect::<String>()


### PR DESCRIPTION
Previously it was outputting a mismatched double quote like this: `key="value`
With this PR it now has a closing quote like this: `key="value"`