### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,5 @@ homepage = "https://github.com/ccakes/prometheus-parse-rs"
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-itertools = { version = "0.12", default-features = false }
-once_cell = { version = "1", default-features = false, features = ["std"] }
+itertools = { version = "0.13", default-features = false }
 regex = { version = "1", default-features = false, features = ["std", "perf", "unicode"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,17 @@
 use chrono::{DateTime, TimeZone, Utc};
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
-static HELP_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^#\s+HELP\s+(\w+)\s+(.+)$").unwrap());
-static TYPE_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^#\s+TYPE\s+(\w+)\s+(\w+)").unwrap());
-static SAMPLE_RE: Lazy<Regex> = Lazy::new(|| {
+static HELP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^#\s+HELP\s+(\w+)\s+(.+)$").unwrap());
+static TYPE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^#\s+TYPE\s+(\w+)\s+(\w+)").unwrap());
+static SAMPLE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^(?P<name>\w+)(\{(?P<labels>[^}]+)\})?\s+(?P<value>\S+)(\s+(?P<timestamp>\S+))?")
         .unwrap()
 });


### PR DESCRIPTION
This PR Updates itertools to 0.13 and updates once_cell by replacing it with [LazyLock](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) the equivalent that has recently landed in the standard library.

This project does not seem to follow an MSRV, so there seems to be no issue with landing such a PR.
However I want to be clear that LazyLock was introduced in rust 1.80 and we are now in 1.81, I think thats a fair amount of time passed for a project with no MSRV specified, but its ultimately your decision to make.